### PR TITLE
Add project name to project page URLs

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -11,6 +11,10 @@ class Project < ApplicationRecord
 
   pg_search_scope :search, against: %i(name description participants looking_for location highlight), using: { tsearch: { any_word: true } }
 
+  def to_param
+    [id, name.parameterize].join("-")
+  end
+
   def volunteer_emails
     self.volunteered_users.collect { |u| u.email }
   end


### PR DESCRIPTION
Using the `5-my-project-name` trick for compatibility with the existing id lookups

I didn't see automated tests, but this works in all my manual tests of get, edit, delete, highlight as expected