### PR TITLE
Adding Basic Search in volunteers page

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,10 +7,18 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def index
     params[:page] ||= 1
 
+    @show_search_bar = true
+
     filtered_users = User
     filtered_users = filtered_users.tagged_with(params[:skill]) if params[:skill].present?
 
-    @users = filtered_users.where(visibility: true).order('created_at DESC').page(params[:page]).per(25)
+    if params[:query].present?
+      grouped_users = filtered_users.search(params[:query])
+    else
+      grouped_users = filtered_users
+    end
+
+    @users = grouped_users.where(visibility: true).order('created_at DESC').page(params[:page]).per(25)
 
     @index_from = (@users.prev_page || 0) * @users.current_per_page + 1
     @index_to = [@index_from + @users.current_per_page - 1, @users.total_count].min

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,12 +6,16 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  include PgSearch
+
   has_many :projects, dependent: :destroy
   has_many :volunteers, dependent: :destroy
   has_many :volunteered_projects, through: :volunteers, source: :project, dependent: :destroy
 
   has_many :offers
   acts_as_taggable_on :skills
+
+  pg_search_scope :search, against: %i(name email about location level_of_availability), using: { tsearch: { any_word: true } }
 
   def volunteered_for_project? project
     self.volunteered_projects.where(id: project.id).exists?

--- a/app/views/devise/registrations/index.html.erb
+++ b/app/views/devise/registrations/index.html.erb
@@ -27,10 +27,22 @@
 <% if @show_filter %>
   <div x-data="{ open: <%= params[:filters_open].present? %> }">
     <div class="block mb-4">
-      <nav class="flex flex-row-reverse">
-        <a href="#" :class="{'bg-gray-200': open}" class="px-3 py-2 font-medium text-sm leading-5 rounded-md text-gray-600 hover:text-gray-800 focus:outline-none focus:text-gray-800 focus:bg-gray-200 fill-current flex-no-wrap" @click.prevent="open = !open" >
+      <nav class="flex flex-col sm:flex-row justify-between">
+        <a href="#" :class="{'bg-gray-200': open}" class="px-3 py-2 font-medium text-sm leading-5 rounded-md text-gray-600 hover:text-gray-800 focus:outline-none focus:text-gray-800 focus:bg-gray-200 fill-current flex-no-wrap mb-4 sm:mb-0" @click.prevent="open = !open" >
           <%= inline_svg_pack_tag('media/svgs/filter-outline.svg', class: 'h-4 inline-block') %> Filter volunteers
         </a>
+        <% if @show_search_bar %>
+          <div class="w-full sm:w-64">
+            <%= form_with url: volunteers_path, local: true, method: :get, html: {'x-ref': 'searchForm'}  do |form| %>
+              <div class="relative rounded-md shadow-sm">
+                <%= form.text_field :query, placeholder: "Search", value: params[:query], class: "form-input block w-full sm:text-sm sm:leading-5" %>
+                <div class="absolute inset-auto right-0 top-0 cursor-pointer" @click="$refs.searchForm.submit()">
+                  <%= inline_svg_pack_tag('media/svgs/search-outline.svg', class: 'translate-y-1/2 mr-2 h-4 inline-block', style: 'margin-top: 10px;') %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
       </nav>
     </div>
     <div :class="{'block': open, 'hidden': !open}" class="hidden">


### PR DESCRIPTION
This includes a search on the volunteers' page. Only visible profiles will be shown in the search results.
This does only search by name, email, about, location and level of availability. 
In a follow-up diff, will add search by skills as well
