### PR TITLE
Allow social shares to go directly to that project's specific page instead of the homepage

### DIFF
--- a/app/views/layouts/_head_content.html.erb
+++ b/app/views/layouts/_head_content.html.erb
@@ -10,7 +10,7 @@
 <meta property="og:type" content="article"/>
 <meta property="og:title" content="<%= content_for(:share_title) || title %>"/>
 <meta property="og:description" content="<%= content_for(:share_desc) || subtitle %>"/>
-<meta property="og:url" content=<%= content_for(:share_url) || "https://www.helpwithcovid.com" %>/>
+<meta property="og:url" content="<%= content_for(:share_url) || "https://www.helpwithcovid.com" %>"/>
 <meta property="og:site_name" content="<%= content_for(:share_title) || title %>"/>
 <meta property="og:image" content="<%= content_for(:share_img) || "https://www.helpwithcovid.com/share-image.png" %>"/>
 <meta property="og:image:width" content="1200"/>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,4 +1,5 @@
 <%- share_title "Project #{@project.name}" %>
+<%- share_url project_url(@project); %>
 
 <div class="bg-white px-4 py-5 border-b border-gray-200 sm:px-6">
   <div class="-ml-4 -mt-4 flex justify-between items-center flex-wrap">


### PR DESCRIPTION
Currently, sharing a specific project page on twitter or facebook, will actually link to the homepage instead.  This pull request should allow social shares (twitter or facebook) of a project page to go directly to that project's specific page.

**Please note that I am not a ruby developer so I am not 100% sure the call to project_url() will output the correct hostname in production.**  

On the development environment I was able to cobble together, the URLs it generated did contain the schema, hostname, and port, e.g.

`http://localhost:3000/projects/1-this-is-a-test`

My expectation is that in production `http://localhost:3000/` will be replaced with `https://www.helpwithcovid.com/` automatically.  If that is not the case please do not merge this pull request.