### PR TITLE
fix: project type filters

### DIFF
--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,19 +1,19 @@
 ALL_SKILLS = [ 'Software', 'Biology', 'Biotech', 'Medicine', 'Mechanics & Electronics', 'Funding', 'Content',  'Manufacturing', 'PM', 'Anything' ].freeze
 ALL_AVAILABILITY = [ '1-2 hours a day', '2-4 hours a day', '4+ hours a day', 'Only on Weekends', 'Full Time' ].freeze
 
-ALL_PROJECT_TYPES = [ 
-  'Track the outbreak', 
+ALL_PROJECT_TYPES = [
+  'Track the outbreak',
   'Reduce spread',
   'Scale testing',
   'Medical facilities',
   'Medical equipments',
-  'Treatment R&D', 
-  'Help out communities', 
-  'Map volunteers to needs',
-  'News and information',
+  'Treatment R&D',
   'E-Learning',
   'Job placement',
   'Mental health',
+  'Help out communities',
+  'Map volunteers to needs',
+  'News and information',
   'Social giving',
   'Other'
   ].freeze


### PR DESCRIPTION
We don't need to do any flex changes. We just need to move some skills around so the top bar can be the same size or larger than the bottom bar. 
At least for the largest monitor size. They will always move around as the monitor size gets smaller.
