### PR TITLE
Fix: sanitize project contact before showing it unescaped (XSS)

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -234,7 +234,7 @@
             How to get in touch
           </dt>
           <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
-            <%= Rinku.auto_link(@project.contact, :all, 'class="text-indigo-500"').html_safe %>
+            <%= Rinku.auto_link(sanitize(@project.contact), :all, 'class="text-indigo-500"').html_safe %>
           </dd>
         </div>
       <% end %>


### PR DESCRIPTION
Fixes an XSS with the autolinking that happens on "How to get in touch" on Projects#show.

Given this input: `An <b>XSS test</b> <script>alert(1)</script> https://google.com foo`

### Before 

<img width="470" alt="Screen Shot 2020-03-21 at 12 30 35 PM" src="https://user-images.githubusercontent.com/5054/77231193-c8a4b200-6b6f-11ea-86d5-01e82cfdde89.png">

<img width="1237" alt="Screen Shot 2020-03-21 at 12 26 01 PM" src="https://user-images.githubusercontent.com/5054/77231168-a448d580-6b6f-11ea-8a4e-59aaa12ccb55.png">

### After

<img width="1236" alt="Screen Shot 2020-03-21 at 12 25 26 PM" src="https://user-images.githubusercontent.com/5054/77231169-a448d580-6b6f-11ea-81a4-f6e727d7afc3.png">
