### PR TITLE
Adds list of skills needed to each project card on listing.

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -16,7 +16,7 @@ class ProjectsController < ApplicationController
     else
       grouped_projects = filtered_projects.left_joins(:volunteers).group(:id)
     end
-    @projects = grouped_projects.includes(:project_types).order('highlight DESC, COUNT(volunteers.id) DESC, created_at DESC').page(params[:page]).per(25)
+    @projects = grouped_projects.includes(:project_types, :skills).order('highlight DESC, COUNT(volunteers.id) DESC, created_at DESC').page(params[:page]).per(25)
 
     @index_from = (@projects.prev_page || 0) * @projects.current_per_page + 1
     @index_to = [@index_from + @projects.current_per_page - 1, @projects.total_count].min

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,7 +71,7 @@ module ApplicationHelper
     base_class
   end
 
-  def filter_badge(label: nil, model: nil, filter_by: nil, color: nil)
+  def filter_badge(label: nil, model: nil, filter_by: nil, color: nil, title: nil)
     if model.present?
       url = "/#{model}?#{filter_by}=#{CGI.escape(label)}&filters_open=true"
     end
@@ -80,18 +80,20 @@ module ApplicationHelper
     when 'gray'
       classes = 'bg-gray-100 text-gray-800'
       classes += ' bg-gray-200' if request.fullpath == url
+    when 'blue'
+      classes = 'bg-blue-100 text-blue-800'
+      classes += ' bg-blue-200' if request.fullpath == url
     when nil
       classes = 'bg-indigo-100 text-indigo-800'
       classes += ' bg-indigo-200' if request.fullpath == url
     end
 
-    render partial: 'partials/filter-badge', locals: {label: label, url: url, classes: classes}
+    render partial: 'partials/filter-badge', locals: {label: label, url: url, classes: classes, title: title}
   end
 
-  def skill_badges(items, show: nil)
-    show ||= items.count
-    extra = items.count > show ? items.dup.drop(show).count : nil
+  def skill_badges(items, limit: nil, color: 'gray', title: title)
+    limit ||= items.count
 
-    render partial: 'partials/skill_badges', locals: {items: items.take(show), extra: extra}
+    render partial: 'partials/skill_badges', locals: {color: color, items: items, limit: limit, title: title}
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -83,7 +83,7 @@ module ApplicationHelper
     when 'blue'
       classes = 'bg-blue-100 text-blue-800'
       classes += ' bg-blue-200' if request.fullpath == url
-    when nil
+    else
       classes = 'bg-indigo-100 text-indigo-800'
       classes += ' bg-indigo-200' if request.fullpath == url
     end
@@ -91,7 +91,7 @@ module ApplicationHelper
     render partial: 'partials/filter-badge', locals: {label: label, url: url, classes: classes, title: title}
   end
 
-  def skill_badges(items, limit: nil, color: 'gray', title: title)
+  def skill_badges(items, limit: nil, color: 'indigo', title: title)
     limit ||= items.count
 
     render partial: 'partials/skill_badges', locals: {color: color, items: items, limit: limit, title: title}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,16 +71,12 @@ module ApplicationHelper
     base_class
   end
 
-  def filter_badge(**args)
-    label = args[:label]
-    model = args[:model]
-    filter_by = args[:filter_by]
-
+  def filter_badge(label: nil, model: nil, filter_by: nil, color: nil)
     if model.present?
       url = "/#{model}?#{filter_by}=#{CGI.escape(label)}&filters_open=true"
     end
 
-    case args[:color]
+    case color
     when 'gray'
       classes = 'bg-gray-100 text-gray-800'
       classes += ' bg-gray-200' if request.fullpath == url
@@ -92,8 +88,8 @@ module ApplicationHelper
     render partial: 'partials/filter-badge', locals: {label: label, url: url, classes: classes}
   end
 
-  def skill_badges(items, **args)
-    show = args[:show].present? ? args[:show] : items.count
+  def skill_badges(items, show: nil)
+    show ||= items.count
     extra = items.count > show ? items.dup.drop(show).count : nil
 
     render partial: 'partials/skill_badges', locals: {items: items.take(show), extra: extra}

--- a/app/views/devise/registrations/_user.html.erb
+++ b/app/views/devise/registrations/_user.html.erb
@@ -13,7 +13,7 @@
       </div>
       <% if user.skill_list.present? %>
         <div class="flex content-center flex-wrap mt-2">
-          <%= skill_badges user.skill_list, show: 3 %>
+          <%= skill_badges user.skill_list, limit: 3 %>
         </div>
       <% end %>
       <div class="mt-2 sm:flex sm:justify-between">

--- a/app/views/devise/registrations/_user.html.erb
+++ b/app/views/devise/registrations/_user.html.erb
@@ -13,7 +13,7 @@
       </div>
       <% if user.skill_list.present? %>
         <div class="flex content-center flex-wrap mt-2">
-          <%= skill_badges user.skill_list, limit: 3 %>
+          <%= skill_badges user.skill_list, limit: 3, color: 'blue' %>
         </div>
       <% end %>
       <div class="mt-2 sm:flex sm:justify-between">

--- a/app/views/devise/registrations/show.html.erb
+++ b/app/views/devise/registrations/show.html.erb
@@ -53,7 +53,7 @@
             Skills
           </dt>
           <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2 flex content-center flex-wrap vertical-spacing-2 -mb-2">
-            <%= skill_badges @user.skill_list %>
+            <%= skill_badges @user.skill_list, color: 'blue' %>
           </dd>
         </div>
       <% end %>

--- a/app/views/partials/_filter-badge.html.erb
+++ b/app/views/partials/_filter-badge.html.erb
@@ -1,8 +1,8 @@
 <% partial_classes = "inline-flex items-center px-2.5 py-0.5 rounded-md text-sm font-medium leading-5 flex-grow-0 #{classes}" %>
 <% if url.present? %>
-  <a href="<%= url %>" class="<%= partial_classes %>">
+  <a href="<%= url %>" class="<%= partial_classes %>" title="<%= title %>">
 <% else %>
-  <div class="<%= partial_classes %>">
+  <div class="<%= partial_classes %>" title="<%= title %>">
 <% end %>
   <svg class="-ml-0.5 mr-1.5 h-2 w-2 text-indigo-400" fill="currentColor" viewBox="0 0 8 8">
     <circle cx="4" cy="4" r="3" />

--- a/app/views/partials/_skill_badges.html.erb
+++ b/app/views/partials/_skill_badges.html.erb
@@ -7,6 +7,6 @@
 <% end %>
 <% if hidden.present? %>
   <div class="mr-2">
-    <%= filter_badge label: "and #{hidden.size} more", color: color, title: hidden.join(", ") %>
+    <%= filter_badge label: "and #{hidden.size} more", color: 'gray', title: hidden.join(", ") %>
   </div>
 <% end %>

--- a/app/views/partials/_skill_badges.html.erb
+++ b/app/views/partials/_skill_badges.html.erb
@@ -1,8 +1,12 @@
-<% items.each do |type| %>
+<% visible, hidden = items.take(limit), items.drop(limit) %>
+
+<% visible.each do |type| %>
   <div class="mr-2">
-    <%= filter_badge label: type %>
+    <%= filter_badge label: type, color: color %>
   </div>
 <% end %>
-<div class="mr-2">
-  <%= filter_badge label: "and #{extra} more", color: 'gray' if extra %>
-</div>
+<% if hidden.present? %>
+  <div class="mr-2">
+    <%= filter_badge label: "and #{hidden.size} more", color: color, title: hidden.join(", ") %>
+  </div>
+<% end %>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -33,7 +33,7 @@
             <%= skill_badges project.project_type_list, limit: 3 %>
           <% end %>
           <% if project.skill_list.present? %>
-            <span class="mt-2 flex items-center text-sm leading-5 text-gray-500 sm:mt-0">looking for &nbsp;</span>
+            <span class="mt-2 flex items-center text-sm leading-5 text-gray-500 sm:mt-0 font-bold">looking for &nbsp;</span>
             <%= skill_badges project.skill_list, limit: 3, color: 'blue' %>
           <% end %>
         </div>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -29,17 +29,13 @@
       </div>
       <% if project.project_type_list.present? || project.skill_list.present?  %>
         <div class="flex flex-row items-start">
-          <% if project.project_type_list.present? %>
-            <div class="flex w-3/5 content-top flex-wrap mt-2">
-              <%= skill_badges project.project_type_list, limit: 3 %>
-            </div>
-          <% end %>
-          <% if project.skill_list.present? %>
-            <div class="flex w-2/5 justify-end content-top flex-wrap mt-2">
-              <span class="mt-2 flex items-center text-sm leading-5 text-gray-500 sm:mt-0 font-bold">looking for: &nbsp;</span>
-              <%= skill_badges project.skill_list, limit: 3, color: 'blue' %>
-            </div>
-          <% end %>
+          <div class="flex w-3/5 content-top flex-wrap mt-2">
+            <%= skill_badges project.project_type_list, limit: 3 %>
+          </div>
+          <div class="flex w-2/5 justify-end content-top flex-wrap mt-2">
+            <span class="mt-2 flex items-center text-sm leading-5 text-gray-500 sm:mt-0 font-bold">looking for: &nbsp;</span>
+            <%= skill_badges project.skill_list, limit: 3, color: 'blue' %>
+          </div>
         </div>
       <% end %>
       <div class="mt-2 sm:flex sm:justify-between">

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -27,14 +27,15 @@
           <%= simple_format project.description, class: 'mb-2' %>
         </div>
       </div>
-      <% if project.skill_list.present? %>
+      <% if project.project_type_list.present? || project.skill_list.present?  %>
         <div class="flex content-center flex-wrap mt-2">
-          <%= skill_badges project.skill_list, limit: 3, color: 'blue' %>
-        </div>
-      <% end %>
-      <% if project.project_type_list.present? %>
-        <div class="flex content-center flex-wrap mt-2">
-          <%= skill_badges project.project_type_list, limit: 3 %>
+          <% if project.skill_list.present? %>
+            <%= skill_badges project.project_type_list, limit: 3 %>
+          <% end %>
+          <% if project.skill_list.present? %>
+            <span class="mt-2 flex items-center text-sm leading-5 text-gray-500 sm:mt-0">looking for &nbsp;</span>
+            <%= skill_badges project.skill_list, limit: 3, color: 'blue' %>
+          <% end %>
         </div>
       <% end %>
       <div class="mt-2 sm:flex sm:justify-between">

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -29,7 +29,7 @@
       </div>
       <% if project.project_type_list.present? || project.skill_list.present?  %>
         <div class="flex flex-row items-start">
-          <% if project.skill_list.present? %>
+          <% if project.project_type_list.present? %>
             <div class="flex w-3/5 content-top flex-wrap mt-2">
               <%= skill_badges project.project_type_list, limit: 3 %>
             </div>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -28,13 +28,17 @@
         </div>
       </div>
       <% if project.project_type_list.present? || project.skill_list.present?  %>
-        <div class="flex content-center flex-wrap mt-2">
+        <div class="flex flex-row items-start">
           <% if project.skill_list.present? %>
-            <%= skill_badges project.project_type_list, limit: 3 %>
+            <div class="flex w-3/5 content-top flex-wrap mt-2">
+              <%= skill_badges project.project_type_list, limit: 3 %>
+            </div>
           <% end %>
           <% if project.skill_list.present? %>
-            <span class="mt-2 flex items-center text-sm leading-5 text-gray-500 sm:mt-0 font-bold">looking for &nbsp;</span>
-            <%= skill_badges project.skill_list, limit: 3, color: 'blue' %>
+            <div class="flex w-2/5 justify-end content-top flex-wrap mt-2">
+              <span class="mt-2 flex items-center text-sm leading-5 text-gray-500 sm:mt-0 font-bold">looking for: &nbsp;</span>
+              <%= skill_badges project.skill_list, limit: 3, color: 'blue' %>
+            </div>
           <% end %>
         </div>
       <% end %>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -27,9 +27,14 @@
           <%= simple_format project.description, class: 'mb-2' %>
         </div>
       </div>
+      <% if project.skill_list.present? %>
+        <div class="flex content-center flex-wrap mt-2">
+          <%= skill_badges project.skill_list, limit: 3, color: 'blue' %>
+        </div>
+      <% end %>
       <% if project.project_type_list.present? %>
         <div class="flex content-center flex-wrap mt-2">
-          <%= skill_badges project.project_type_list, show: 3 %>
+          <%= skill_badges project.project_type_list, limit: 3 %>
         </div>
       <% end %>
       <div class="mt-2 sm:flex sm:justify-between">

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -32,10 +32,12 @@
           <div class="flex w-3/5 content-top flex-wrap mt-2">
             <%= skill_badges project.project_type_list, limit: 3 %>
           </div>
-          <div class="flex w-2/5 justify-end content-top flex-wrap mt-2">
-            <span class="mt-2 flex items-center text-sm leading-5 text-gray-500 sm:mt-0 font-bold">looking for: &nbsp;</span>
-            <%= skill_badges project.skill_list, limit: 3, color: 'blue' %>
-          </div>
+          <% if project.skill_list.present? %>
+            <div class="flex w-2/5 justify-end content-top flex-wrap mt-2">
+              <span class="mt-2 flex items-center text-sm leading-5 text-gray-500 sm:mt-0 font-bold">looking for: &nbsp;</span>
+              <%= skill_badges project.skill_list, limit: 3, color: 'blue' %>
+            </div>
+          <% end %>
         </div>
       <% end %>
       <div class="mt-2 sm:flex sm:justify-between">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -281,7 +281,7 @@
             Skills needed
           </dt>
           <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2 flex content-center flex-wrap vertical-spacing-2 -mb-2">
-            <%= skill_badges @project.skill_list %>
+            <%= skill_badges @project.skill_list, color: 'blue' %>
           </dd>
         </div>
       <% end %>


### PR DESCRIPTION
This  adds "Skill Types" list above "Project Types" on the Project cards 

Also:
  * adds `title` attribute to "and X more" element
  * use 'blue' for "Skill Types" to differentiate from "Project Type" indigo.
  * some small refactoring

### Before

<img width="1237" alt="Screen Shot 2020-03-21 at 7 54 57 PM" src="https://user-images.githubusercontent.com/5054/77239188-0f190180-6bae-11ea-8ad3-1d795a34a5f1.png">

### After

<img width="1233" alt="Screen Shot 2020-03-21 at 10 34 21 PM" src="https://user-images.githubusercontent.com/5054/77241090-219e3580-6bc4-11ea-9623-1c87f5b8c507.png">
