### PR TITLE
Show user count on volunteer page

### DIFF
--- a/app/views/devise/registrations/index.html.erb
+++ b/app/views/devise/registrations/index.html.erb
@@ -4,7 +4,7 @@
   <div class="-ml-4 -mt-4 flex justify-between items-center flex-wrap sm:flex-no-wrap">
     <div class="ml-4 mt-4">
       <h3 class="text-lg leading-6 font-medium text-gray-900">
-        Volunteers from around the world
+        <%= pluralize(User.count, 'volunteer') %> from around the world
       </h3>
       <p class="mt-1 text-sm leading-5 text-gray-500">
         They have all offered to help out with COVID-19 related projects.


### PR DESCRIPTION
Just an idea! Take it or leave it:

### Before

<img width="1237" alt="Screen Shot 2020-03-21 at 10 37 04 PM" src="https://user-images.githubusercontent.com/5054/77241185-139ce480-6bc5-11ea-9a3b-f359c653b645.png">

### After

<img width="1237" alt="Screen Shot 2020-03-21 at 10 38 49 PM" src="https://user-images.githubusercontent.com/5054/77241183-139ce480-6bc5-11ea-89e4-06c71e336ac0.png">
