### PR TITLE
Making the search and

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -9,7 +9,7 @@ class Project < ApplicationRecord
   acts_as_taggable_on :skills
   acts_as_taggable_on :project_types
 
-  pg_search_scope :search, against: %i(name description participants looking_for location highlight), using: { tsearch: { any_word: true } }
+  pg_search_scope :search, against: %i(name description participants looking_for location highlight)
 
   def to_param
     [id, name.parameterize].join("-")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
   has_many :offers
   acts_as_taggable_on :skills
 
-  pg_search_scope :search, against: %i(name email about location level_of_availability), using: { tsearch: { any_word: true } }
+  pg_search_scope :search, against: %i(name email about location level_of_availability)
 
   def volunteered_for_project? project
     self.volunteered_projects.where(id: project.id).exists?


### PR DESCRIPTION
The search is now and. It will show better results. 

All the words in search now must match in the project. If all the words occur across multiple places in the project(title, description, etc), it will be still be considered as a match.