### PR TITLE
feat: new project index tags proposal

### DIFF
--- a/app/frontend/packs/stylesheets.css
+++ b/app/frontend/packs/stylesheets.css
@@ -1,8 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-.vertical-spacing-2 >*+* {
-  @apply mb-2;
-}
-

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -91,9 +91,9 @@ module ApplicationHelper
     render partial: 'partials/filter-badge', locals: {label: label, url: url, classes: classes, title: title}
   end
 
-  def skill_badges(items, limit: nil, color: 'indigo', title: title, align: 'left')
+  def skill_badges(items, limit: nil, color: 'indigo', title: title)
     limit ||= items.count
 
-    render partial: 'partials/skill_badges', locals: {color: color, items: items, limit: limit, title: title, align: align}
+    render partial: 'partials/skill_badges', locals: {color: color, items: items, limit: limit, title: title}
   end
 end

--- a/app/views/devise/registrations/_user.html.erb
+++ b/app/views/devise/registrations/_user.html.erb
@@ -12,7 +12,7 @@
         </div>
       </div>
       <% if user.skill_list.present? %>
-        <div class="flex content-center flex-wrap mt-2">
+        <div class="flex content-center flex-wrap mt-2 space-x-right-2">
           <%= skill_badges user.skill_list, limit: 3, color: 'blue' %>
         </div>
       <% end %>

--- a/app/views/devise/registrations/show.html.erb
+++ b/app/views/devise/registrations/show.html.erb
@@ -52,7 +52,7 @@
           <dt class="text-sm leading-5 font-medium text-gray-500">
             Skills
           </dt>
-          <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2 flex content-center flex-wrap vertical-spacing-2 -mb-2">
+          <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2 flex content-center flex-wrap space-y-bottom-2 -mb-2 space-x-right-2">
             <%= skill_badges @user.skill_list, color: 'blue' %>
           </dd>
         </div>

--- a/app/views/partials/_skill_badges.html.erb
+++ b/app/views/partials/_skill_badges.html.erb
@@ -1,12 +1,8 @@
 <% visible, hidden = items.take(limit), items.drop(limit) %>
 
 <% visible.each do |type| %>
-  <div class="<%= align == 'left' ? 'mr-2' : 'ml-2' %>">
-    <%= filter_badge label: type, color: color %>
-  </div>
+  <%= filter_badge label: type, color: color %>
 <% end %>
 <% if hidden.present? %>
-  <div class="<%= align == 'left' ? 'mr-2' : 'ml-2' %>">
-    <%= filter_badge label: "and #{hidden.size} more", color: 'gray', title: hidden.join(", ") %>
-  </div>
+  <%= filter_badge label: "and #{hidden.size} more", color: 'gray', title: hidden.join(", ") %>
 <% end %>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -28,14 +28,19 @@
         </div>
       </div>
       <% if project.project_type_list.present? || project.skill_list.present?  %>
-        <div class="flex flex-row items-start">
-          <div class="flex w-3/5 content-top flex-wrap mt-2">
-            <%= skill_badges project.project_type_list, limit: 3 %>
+        <div class="flex flex-col md:flex-row items-start justify-between">
+          <div class="flex flex-col  flex-1 justify-end flex-wrap mt-2">
+            <div class="mt-2 text-sm leading-5 text-gray-500 sm:mt-0 font-bold">Helping with: </div>
+            <div class="flex flex-row flex-wrap space-x-right-2 space-y-top-2">
+              <%= skill_badges project.project_type_list, limit: 3 %>
+            </div>
           </div>
           <% if project.skill_list.present? %>
-            <div class="flex w-3/5 justify-end content-top flex-wrap mt-2">
-              <span class="mt-2 flex items-center text-sm leading-5 text-gray-500 sm:mt-0 font-bold">looking for: &nbsp;</span>
-              <%= skill_badges project.skill_list, limit: 3, color: 'blue', align: 'right' %>
+            <div class="flex flex-col md:justify-end flex-wrap mt-2">
+              <div class="mt-2 text-sm md:text-right leading-5 text-gray-500 sm:mt-0 font-bold">Looking for:</div>
+              <div class="flex flex-row flex-wrap md:items-end md:content-end md:justify-end space-x-right-2 md:space-x-right-0 md:space-x-left-2 space-y-top-2">
+                <%= skill_badges project.skill_list, limit: 3, color: 'blue' %>
+              </div>
             </div>
           <% end %>
         </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -280,7 +280,7 @@
           <dt class="text-sm leading-5 font-medium text-gray-500">
             Skills needed
           </dt>
-          <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2 flex content-center flex-wrap vertical-spacing-2 -mb-2">
+          <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2 flex content-center flex-wrap space-y-bottom-2 -mb-2 space-x-right-2">
             <%= skill_badges @project.skill_list, color: 'blue' %>
           </dd>
         </div>
@@ -291,7 +291,7 @@
           <dt class="text-sm leading-5 font-medium text-gray-500">
             Project type
           </dt>
-          <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2 flex content-center flex-wrap vertical-spacing-2 -mb-2">
+          <dd class="mt-1 text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2 flex content-center flex-wrap space-y-bottom-2 -mb-2 space-x-right-2">
             <%= skill_badges @project.project_type_list %>
           </dd>
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+const plugin = require('tailwindcss/plugin')
+
 module.exports = {
   theme: {
     extend: {},
@@ -5,5 +7,46 @@ module.exports = {
   variants: {},
   plugins: [
     require('@tailwindcss/ui'),
+    /*
+    * Spacing utilities
+    * Ex: .space-y-bottom-2 space-x-right-4
+    */
+    plugin(function({ addUtilities, theme }) {
+      const property = 'margin'
+      const axes = ['x', 'y']
+      const directions = {
+        x: ['right', 'left'],
+        y: ['top', 'bottom'],
+      }
+      let utilities = {}
+
+      axes.forEach((axis) => {
+        directions[axis].forEach((direction) => {
+          const spacing = []
+
+          Object.keys(theme('spacing')).filter((key) => {
+            // fetching only the absolute values (numbers, no 1/2, 3/5, etc.)
+            if (!key.includes('/')) {
+              spacing[key] = theme('spacing')[key];
+            }
+          })
+
+          Object.keys(spacing).forEach((key) => {
+            const value = spacing[key]
+            const className = `.space-${axis}-${direction}-${key}`
+
+            const childrenProperties = {}
+            childrenProperties[`${property}-${direction}`] = value
+
+            const properties = {
+              '>*' : childrenProperties,
+            }
+            utilities[className] = properties
+          })
+        })
+      })
+
+      addUtilities(utilities, {variants: ['responsive']})
+    }),
   ],
 }


### PR DESCRIPTION
I am proposing a slight change in how we show the skills and project types on the homepage. Right now the tags get justified weird in certain screen sizes.

### What I'm proposing:
1. Have labels for both tag "clouds" (project type and skils needed)
2. Collapse the tag clouds when on mobile

### Tech changes
Because we are moving the skills tags from the right on mobile to the left on desktop, we need to change the alignment of each tag. To be more precise the margin from the left to the right. At the moment we're doing that with ruby code that isn't aware of the responsive changes. We may set it to the right or to the left on runtime and that's it.
I added a tailwind plugin that adds spacer utilities (`.space-x-right-4`, .md:space-y-bottom-2, etc.) that space the children elements and allow us to change the spacing direction based on screen size.
So now, we don't need to add margins (left or right) on the tags, we can just add a spacer class on the parent and let it do it's thing.

Before mobile:
![image](https://user-images.githubusercontent.com/1334409/77247291-446a3180-6c38-11ea-90a9-bb0e3b35f00a.png)
After mobile:
![image](https://user-images.githubusercontent.com/1334409/77247294-4cc26c80-6c38-11ea-80dc-a1c565453394.png)

Before desktop:
![image](https://user-images.githubusercontent.com/1334409/77247299-5d72e280-6c38-11ea-95a2-dc64672fe08b.png)

After desktop:
![image](https://user-images.githubusercontent.com/1334409/77247302-65328700-6c38-11ea-9f86-2b030980a28b.png)
