### PR TITLE
Add json response to ProjectsController#index and #show

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -31,10 +31,7 @@ class ProjectsController < ApplicationController
         @total_count = @projects.total_count
       end
       format.json do
-        render json: @projects.as_json(
-          only: [:name, :description, :location, :created_at],
-          methods: [:to_param, :volunteered_users_count, :project_type_list, :skill_list]
-        )
+        render json: @projects
       end
     end
   end
@@ -70,6 +67,7 @@ class ProjectsController < ApplicationController
     respond_to do |format|
       format.html
       format.csv { send_data @project.volunteered_users.to_csv, filename: "volunteers-#{Date.today}.csv" }
+      format.json { render json: @project }
     end
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -16,15 +16,27 @@ class ProjectsController < ApplicationController
     else
       grouped_projects = filtered_projects.left_joins(:volunteers).group(:id)
     end
-    @projects = grouped_projects.includes(:project_types, :skills).order('highlight DESC, COUNT(volunteers.id) DESC, created_at DESC').page(params[:page]).per(25)
+    @projects = grouped_projects.includes(:project_types, :skills).order('highlight DESC, COUNT(volunteers.id) DESC, created_at DESC')
 
-    @index_from = (@projects.prev_page || 0) * @projects.current_per_page + 1
-    @index_to = [@index_from + @projects.current_per_page - 1, @projects.total_count].min
-    @total_count = @projects.total_count
+    respond_to do |format|
+      format.html do
+        @projects_header = 'COVID-19 projects looking for volunteers'
+        @projects_subheader = 'New or established projects helping with the COVID-19 crisis that need help. Volunteer yourself or create a new one.'
+        @page_title = 'All Projects'
 
-    @projects_header = 'COVID-19 projects looking for volunteers'
-    @projects_subheader = 'New or established projects helping with the COVID-19 crisis that need help. Volunteer yourself or create a new one.'
-    @page_title = 'All Projects'
+        @projects = @projects.page(params[:page]).per(25)
+
+        @index_from = (@projects.prev_page || 0) * @projects.current_per_page + 1
+        @index_to = [@index_from + @projects.current_per_page - 1, @projects.total_count].min
+        @total_count = @projects.total_count
+      end
+      format.json do
+        render json: @projects.as_json(
+          only: [:name, :description, :location, :created_at],
+          methods: [:to_param, :volunteered_users_count, :project_type_list, :skill_list]
+        )
+      end
+    end
   end
 
   def volunteered

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -18,4 +18,8 @@ class Project < ApplicationRecord
   def volunteer_emails
     self.volunteered_users.collect { |u| u.email }
   end
+
+  def volunteered_users_count
+    volunteered_users.count
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -24,6 +24,24 @@ class Project < ApplicationRecord
   end
 
   def serializable_hash(options={})
-    super(methods: [:to_param, :volunteered_users_count, :project_type_list, :skill_list])
+    super(
+      only: [
+        :id,
+        :name,
+        :description,
+        :participants,
+        :goal,
+        :looking_for,
+        :location,
+        :contact,
+        :highlight,
+        :progress,
+        :docs_and_demo,
+        :number_of_volunteers,
+        :created_at,
+        :updated_at
+      ],
+      methods: [:to_param, :volunteered_users_count, :project_type_list, :skill_list]
+    )
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -22,4 +22,8 @@ class Project < ApplicationRecord
   def volunteered_users_count
     volunteered_users.count
   end
+
+  def serializable_hash(options={})
+    super(methods: [:to_param, :volunteered_users_count, :project_type_list, :skill_list])
+  end
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe ProjectsController, type: :controller do
       expect(response).to be_successful
       expect(assigns(:projects)).to include(project)
     end
+
+    it 'returns json' do
+      get :index, format: 'json'
+      json = JSON.parse(response.body)
+      expect(response).to be_successful
+      expect(json[0]["name"]).to eq(project.name)
+      expect(json[0]["description"]).to eq(project.description)
+      expect(json[0]["location"]).to eq(project.location)
+      expect(json[0]["to_param"]).to eq(project.to_param)
+    end
   end
 
   describe 'GET #show' do

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe ProjectsController, type: :controller do
       expect(response).to be_successful
       expect(assigns(:project)).to eq(project)
     end
+
+    it 'returns json' do
+      get :show, params: { id: project.to_param }, format: 'json'
+      json = JSON.parse(response.body)
+      expect(response).to be_successful
+      expect(json["name"]).to eq(project.name)
+      expect(json["description"]).to eq(project.description)
+      expect(json["location"]).to eq(project.location)
+      expect(json["to_param"]).to eq(project.to_param)
+    end
   end
 
   describe 'GET #new' do


### PR DESCRIPTION
Allows JSON export of projects to `Projects#index` and `Projects#show` by returning this data from each one (unpaginated):

```
{
  "id":2,
  "name":"OpenCrisisBoard project",
  "description":"\r\nOpenCrisisBoard is an open-source ready-to...",
  "participants":"Our team previously worked on the Ebola response and ...",
  "looking_for":"We need help with:\r\n- develop...",
  "created_at":"2020-03-21T13:59:35.325Z",
  "updated_at":"2020-03 21T15:34:13.817Z",
  "location":"remote",
  "contact":"",
  "highlight":true,
  "progress":"",
  "docs_and_demo":"",
  "number_of_volunteers":"",
  "to_param":"2-opencrisisboard-project", 
  "volunteered_users_count":0,
  "project_type_list":["Mental health","Map volunteers to needs","Medical equipments","Track the outbreak"],
  "skill_list":["PM","Software"]}
}
```


Fixes #35